### PR TITLE
fix: Closes #10 by updating deprecated set-output

### DIFF
--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -34,7 +34,7 @@ jobs:
         # Remove "/fix".
         noFix="${noFeature/fix/}"
         # Shorten name to 20 characters. Set it as output of the name "branch_name".
-        echo "::set-output name=branch_name::$( echo $noFix | cut -c 1-20 )"
+        echo "branch_name=$( echo $noFix | cut -c 1-20 )" >> $GITHUB_OUTPUT
       id: normalize
 
   feature-branch:

--- a/.github/workflows/gitversion.yml
+++ b/.github/workflows/gitversion.yml
@@ -47,11 +47,11 @@ jobs:
       # prerelease_version: {suffix from inputs}{commit count since last release tag}-{run-count, not raised by re-run}
       # Example: -alpha0008-42
       run: |
-        echo "::set-output name=prerelease_suffix::-${{ inputs.suffix }}$(printf %4s ${{ steps.gitversion.outputs.increment }} | tr ' ' 0)-${{ github.run_number }}"
+        echo "prerelease_suffix=-${{ inputs.suffix }}$(printf %4s ${{ steps.gitversion.outputs.increment }} | tr ' ' 0)-${{ github.run_number }}" >> $GITHUB_OUTPUT
       id: prerelease_version
       
     - name: Output version
       # If input "prerelease" == false, then steps.prerelease_version.outputs.prerelease_suffix will be empty.
       run: |
-           echo "::set-output name=final_version::${{ steps.gitversion.outputs.version }}${{ steps.prerelease_version.outputs.prerelease_suffix }}"
+        echo "final_version=${{ steps.gitversion.outputs.version }}${{ steps.prerelease_version.outputs.prerelease_suffix }}" >> $GITHUB_OUTPUT
       id: nuget_version                                                # Output name.

--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ Two of the workflows require secrets to be passed on to work as intended:
 
 * `publish.yml` pushes NuGet packages to nuget.org and needs a personal access token named `NUGET_FEED_PAT` with proper permissions
 * `create-release.yml` creates commits, merges and creates branches and pushes to the target repository and need a GitHub personal access token name `PUSH_TO_GITHUB_REPO_PAT` with proper permissions
+  - the only permission to be set is `public_repo`


### PR DESCRIPTION
[set-output has been marked deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/). This PR closes #10 by replacing it.