### PR TITLE
Issue 18: Skip actions triggered by back-merge

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -75,7 +75,8 @@ jobs:
           echo Checkout develop
           git checkout develop
           echo Merge back main into develop
-          git merge --no-ff main
+          # We add [skip actions] to the merge commit message to suppress triggering other workflows by the following push.
+          git merge --no-ff --no-edit -m "[skip actions] merge back 'main' into 'develop'" main
           
       - name: Push all branches
         run: |


### PR DESCRIPTION
Skips actions triggered by pushing into `develop` after merging back `main` on creating a release.

Closes #18