### PR TITLE
chore: Updates checkout and semantic-version

### DIFF
--- a/.github/workflows/build-and-pack.yml
+++ b/.github/workflows/build-and-pack.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: windows-latest
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
            
     - name: Setup .NET
       uses: actions/setup-dotnet@v2

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -48,7 +48,7 @@ jobs:
       contents: write
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           # Invoking workflow has to pass a personal access token with permission to pull/push on the target repo.

--- a/.github/workflows/create-support-release.yml
+++ b/.github/workflows/create-support-release.yml
@@ -57,7 +57,7 @@ jobs:
       contents: write
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.PUSH_TO_GITHUB_REPO_PAT }}

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -31,7 +31,7 @@ jobs:
       branch_name: ${{ steps.normalize.outputs.branch_name }}
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Normalize branch name
       run: |
         # Take the branch name by GitHub variable "ref_name".

--- a/.github/workflows/gitversion.yml
+++ b/.github/workflows/gitversion.yml
@@ -46,7 +46,7 @@ jobs:
       semver_raise_type: ${{ steps.gitversion.outputs.version_type }}
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         # Checkout the full repo.
         fetch-depth: 0
@@ -54,7 +54,7 @@ jobs:
     - name: Git Versioning
       id: gitversion
        # Run a custom action from there.
-      uses: paulhatch/semantic-version@v5.0.3
+      uses: paulhatch/semantic-version@v5.4.0
       with:
         # Define the format for assembling the version number.
         tag_prefix: "release/"


### PR DESCRIPTION
NodeJS 16 became deprecated. checkout@v3 depended on that and has been updated to v4. The same is true for semantic-version.