### PR TITLE
fix: Remove token since it is persisted automatically now

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -51,8 +51,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # Invoking workflow has to pass a personal access token with permission to pull/push on the target repo.
-          token: ${{ secrets.PUSH_TO_GITHUB_REPO_PAT }}
           
       - name: Save NuGet version to a variable for easy access.
         run: |

--- a/.github/workflows/create-support-release.yml
+++ b/.github/workflows/create-support-release.yml
@@ -60,7 +60,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.PUSH_TO_GITHUB_REPO_PAT }}
           
       - name: Save NuGet version to a variable for easy access.
         run: |

--- a/README.md
+++ b/README.md
@@ -85,5 +85,4 @@ Publish the build artifact (NuGet package) to a target nuget feed.
 Two of the workflows require secrets to be passed on to work as intended:
 
 * `publish.yml` pushes NuGet packages to nuget.org and needs a personal access token named `NUGET_FEED_PAT` with proper permissions
-* `create-release.yml` creates commits, merges and creates branches and pushes to the target repository and need a GitHub personal access token name `PUSH_TO_GITHUB_REPO_PAT` with proper permissions
-  - the only permission to be set is `public_repo`
+* `create-release.yml` creates commits, merges and creates branches and pushes to the target repository


### PR DESCRIPTION
The manually handed token causes an error since [it is not necessary](https://github.com/actions/checkout?tab=readme-ov-file#push-a-commit-using-the-built-in-token) anymore.