### PR TITLE
feat: Add gh-pages build&deploy action

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,65 @@
+# This workflow
+# + builds GitHub Pages content using Jekyll
+# + deploys the artifacts to GitHub Pages
+#
+# This workflow must run on the branch where the GitHub Pages source content is located.
+# This workflow must be called from other workflows.
+
+name: Deploy GitHub Pages
+
+on:
+  workflow_call: # Called by other workflows only.
+    inputs:
+      source:
+        description: 'The directory to build GitHub Pages from.'
+        required: false
+        type: string
+        default: './'
+      destination:
+        description: 'The directory to build GitHub Pages to.'
+        required: false
+        type: string
+        default: './_site'
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ${{ inputs.source }}
+          destination: ${{ inputs.destination }}
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ${{ inputs.destination }}
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -80,6 +80,17 @@ Publish the build artifact (NuGet package) to a target nuget feed.
 |----------|-----------|--------|----|
 |`target`|Define the target feed to push the artifact (e.g. nuget.org).|yes|`string`|
 
+## Action `deploy-gh-pages.yml`
+
+Build GitHub Pages content using Jekyll and deploy the artifactes to the GitHub Pages of your repository.
+
+### Inputs
+
+|Input name|Description|Required|Type|Default value|
+|----------|-----------|--------|----|-------------|
+|`source`|The directory to build GitHub Pages from.|no|`string`|`./`|
+|`destination`|The directory to build GitHub Pages to.|no|`string`|`./_site`|
+
 ## Secrets
 
 Two of the workflows require secrets to be passed on to work as intended:


### PR DESCRIPTION
The GitHub Pages Legacy Worker will sunset June 2024, meaning the old way of automatically building from the gh-pages branch will no longer work. The new way is using GitHub actions.
This PR adds a new action to build and deploy the GitHub pages content (using Jekyll, basically the same things the legacy worker did behind the curtains). The action is adapted from the official sample.

Notes:
The action must run on the branch where the content is located, e.g. gh-pages branch. This means that your calling .yml must reside there, and not in main/develop, unless your doc is located there.
You need to choose the .yml as the way to deploy your GitHub pages (repository settings -> Pages -> Build and deployment -> source)