### PR TITLE
feat: Update artifacts action to v4

### DIFF
--- a/.github/workflows/build-and-pack.yml
+++ b/.github/workflows/build-and-pack.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Upload artifacts
       # Upload all NuGet packages to GitHub. Artifact name "packages".
       if: inputs.do_pack
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: packages
         path: src/package_output/*.nupkg

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Download nugets from artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: packages
         path: package_output


### PR DESCRIPTION
- updates artifacts action to v4, v3 is deprecated
- no other changes should be necessary